### PR TITLE
Fix arcane tools always draining mana

### DIFF
--- a/src/main/java/shadowfox/botanicaladdons/common/integration/tinkers/traits/TraitArcane.kt
+++ b/src/main/java/shadowfox/botanicaladdons/common/integration/tinkers/traits/TraitArcane.kt
@@ -14,8 +14,12 @@ class TraitArcane : AbstractTrait("arcane", TinkersIntegration.MANASTEEL_COLOR) 
     val manaPer = 30
 
     override fun onUpdate(tool: ItemStack, world: World, entity: Entity, itemSlot: Int, isSelected: Boolean) {
-        if (entity is EntityPlayer && ManaItemHandler.requestManaExactForTool(tool, entity, 3 * manaPer, true))
-            ToolHelper.healTool(tool, 1, entity)
+        if (entity is EntityPlayer && ManaItemHandler.requestManaExactForTool(tool, entity, 3 * manaPer, false)) {
+            if(ToolHelper.getCurrentDurability(tool) < ToolHelper.getMaxDurability(tool)) {
+                ToolHelper.healTool(tool, 1, entity)
+                ManaItemHandler.requestManaExactForTool(tool, entity, 3 * manaPer, true)
+            }
+        }
     }
 
     override fun onToolDamage(tool: ItemStack?, damage: Int, newDamage: Int, entity: EntityLivingBase?): Int {


### PR DESCRIPTION
The Arcane tool trait on Tinkers Construct tools was draining mana from
the player to repair itself, even when the tool was fully repaired.

Resolves: #36